### PR TITLE
I2 stories by user

### DIFF
--- a/blackcat/blackcat/storysharing/templates/storysharing/public_stories.html
+++ b/blackcat/blackcat/storysharing/templates/storysharing/public_stories.html
@@ -3,12 +3,15 @@
 {% block content %}
 
 <div class="main">
-    <p class="header">Stories</p>
+    <p class="header">Public stories{% if writer %} by {{ writer.username }}{% endif %}</p>
     {% for story in object_list %}
         <p class="listlinks">
             <a href="{% url 'display_story' story.id %}">{{ story.title }}</a> by {% for writer in story.writers.get_queryset %}<a href="{% url 'stories' %}?writer={{ writer.username }}">{{ writer }}</a>, {% endfor %}
         </p>
     {% endfor %}
+    {% if writer %}
+        <p class="links"><a href="{% url 'stories' %}"> > Go back to all public stories < </a></p>
+    {% endif %}
 </div>
 
 {% endblock %}

--- a/blackcat/blackcat/storysharing/templates/storysharing/public_stories.html
+++ b/blackcat/blackcat/storysharing/templates/storysharing/public_stories.html
@@ -6,7 +6,7 @@
     <p class="header">Stories</p>
     {% for story in object_list %}
         <p class="listlinks">
-            <a href="{% url 'display_story' story.id %}">{{ story.title }}</a> by {% for writer in story.writers.get_queryset %}{{ writer }}, {% endfor %}
+            <a href="{% url 'display_story' story.id %}">{{ story.title }}</a> by {% for writer in story.writers.get_queryset %}<a href="{% url 'stories' %}?writer={{ writer.username }}">{{ writer }}</a>, {% endfor %}
         </p>
     {% endfor %}
 </div>

--- a/blackcat/blackcat/storysharing/templates/storysharing/public_stories.html
+++ b/blackcat/blackcat/storysharing/templates/storysharing/public_stories.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <div class="main">
-    <p class="header">Public stories{% if writer %} by {{ writer.username }}{% endif %}</p>
+    <p class="header">Public Stories{% if writer %} by {{ writer.username }}{% endif %}</p>
     {% for story in object_list %}
         <p class="listlinks">
             <a href="{% url 'display_story' story.id %}">{{ story.title }}</a> by {% for writer in story.writers.get_queryset %}<a href="{% url 'stories' %}?writer={{ writer.username }}">{{ writer }}</a>, {% endfor %}

--- a/blackcat/blackcat/storysharing/templates/storysharing/public_stories.html
+++ b/blackcat/blackcat/storysharing/templates/storysharing/public_stories.html
@@ -3,13 +3,13 @@
 {% block content %}
 
 <div class="main">
-    <p class="header">Public Stories{% if writer %} by {{ writer.username }}{% endif %}</p>
+    <p class="header">Public Stories{% if filtered_writer %} by {{ filtered_writer.username }}{% endif %}</p>
     {% for story in object_list %}
         <p class="listlinks">
             <a href="{% url 'display_story' story.id %}">{{ story.title }}</a> by {% for writer in story.writers.get_queryset %}<a href="{% url 'stories' %}?writer={{ writer.username }}">{{ writer }}</a>, {% endfor %}
         </p>
     {% endfor %}
-    {% if writer %}
+    {% if filtered_writer %}
         <p class="links"><a href="{% url 'stories' %}"> > Go back to all public stories < </a></p>
     {% endif %}
 </div>

--- a/blackcat/blackcat/storysharing/views.py
+++ b/blackcat/blackcat/storysharing/views.py
@@ -46,7 +46,7 @@ class PublicStoriesView(ListView):
             writer = User.objects.filter(username=request.GET['writer'])[0]
             self.object_list = self.get_queryset().filter(writers__in=[writer])
             context = self.get_context_data()
-            context['writer'] = writer
+            context['filtered_writer'] = writer
             return self.render_to_response(context)
         return super().get(request, *args, **kwargs)
 

--- a/blackcat/blackcat/storysharing/views.py
+++ b/blackcat/blackcat/storysharing/views.py
@@ -41,6 +41,14 @@ class PublicStoriesView(ListView):
     model = Story
     template_name = 'storysharing/public_stories.html'
 
+    def get(self, request, *args, **kwargs):
+        if 'writer' in request.GET:
+            writer = User.objects.filter(username=request.GET['writer'])[0]
+            self.object_list = self.get_queryset().filter(writers__in=[writer])
+            context = self.get_context_data()
+            return self.render_to_response(context)
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         return Story.objects.filter(public=True).order_by('title')
 

--- a/blackcat/blackcat/storysharing/views.py
+++ b/blackcat/blackcat/storysharing/views.py
@@ -46,6 +46,7 @@ class PublicStoriesView(ListView):
             writer = User.objects.filter(username=request.GET['writer'])[0]
             self.object_list = self.get_queryset().filter(writers__in=[writer])
             context = self.get_context_data()
+            context['writer'] = writer
             return self.render_to_response(context)
         return super().get(request, *args, **kwargs)
 


### PR DESCRIPTION
Filter public stories by writer and display them on click on a writer's username in the public stories page.

It addresses issue #2. However, not all stories from a writer visible by the logged in user are displayed, only the public ones (i.e. if a user is another writer of a private story by the filtered writer, the logged in user can view this private story in his list of personal stories but they are not displayed together with the public stories from the filtered writer).